### PR TITLE
[CODEME-580] - Change Gradle compile to implementation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,6 +40,6 @@ repositories {
 
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile 'com.google.android.gms:play-services-location:11.0.0'
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.google.android.gms:play-services-location:11.0.0'
 }


### PR DESCRIPTION
This is a necessary adjustment to compile with React Native v0.68